### PR TITLE
Bring back `ember-get-config`

### DIFF
--- a/addon/components/eh-background.js
+++ b/addon/components/eh-background.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { htmlSafe } from '@ember/template';
 import { inject as service } from '@ember/service';
-import { getOwner } from '@ember/application';
+import config from 'ember-get-config';
 
 export default class EHBackgroundComponent extends Component {
   @service ehHotspots;
@@ -25,7 +25,6 @@ export default class EHBackgroundComponent extends Component {
 
   get style() {
     const { width, height } = this.backgroundImageInfo;
-    const config = getOwner(this).resolveRegistration('config:environment');
     const src = config.rootURL + this.args.src;
     const styles = [
       `background-image:url(${src})`,

--- a/addon/components/eh-hotspot.js
+++ b/addon/components/eh-hotspot.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { htmlSafe } from '@ember/template';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { getOwner } from '@ember/application';
+import config from 'ember-get-config';
 
 export default class EHHotspotComponent extends Component {
   @service router;
@@ -47,7 +47,6 @@ export default class EHHotspotComponent extends Component {
     if (this.args.src) {
       const { width: imageWidth, height: imageHeight } =
         this.backgroundImageInfo;
-      const config = getOwner(this).resolveRegistration('config:environment');
       const src = config.rootURL + this.args.src;
 
       styles.push(

--- a/addon/services/eh-hotspots.js
+++ b/addon/services/eh-hotspots.js
@@ -1,7 +1,7 @@
 import Service from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import fetch from 'fetch';
-import { getOwner } from '@ember/application';
+import config from 'ember-get-config';
 
 export default class EhHotspotsService extends Service {
   @tracked showHotspots = false;
@@ -41,7 +41,6 @@ export default class EhHotspotsService extends Service {
     }
 
     try {
-      const config = getOwner(this).resolveRegistration('config:environment');
       const file = 'assets/eh-hotspots.json';
       const res = await fetch(`${config.rootURL}${file}`);
       const data = await res.json();

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "ember-cli-terser": "4.0.2",
     "ember-disable-prototype-extensions": "1.1.3",
     "ember-export-application-global": "2.0.1",
+    "ember-get-config": "2.0.0",
     "ember-load-initializers": "2.1.2",
     "ember-page-title": "7.0.0",
     "ember-qunit": "5.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ specifiers:
   ember-disable-prototype-extensions: 1.1.3
   ember-export-application-global: 2.0.1
   ember-fetch: 8.1.1
+  ember-get-config: 2.0.0
   ember-load-initializers: 2.1.2
   ember-page-title: 7.0.0
   ember-qunit: 5.1.5
@@ -82,6 +83,7 @@ devDependencies:
   ember-cli-terser: 4.0.2
   ember-disable-prototype-extensions: 1.1.3
   ember-export-application-global: 2.0.1
+  ember-get-config: 2.0.0
   ember-load-initializers: 2.1.2
   ember-page-title: 7.0.0
   ember-qunit: 5.1.5_68c27f1128862f3e803be47c98c5e80a
@@ -5075,6 +5077,16 @@ packages:
       - encoding
       - supports-color
     dev: false
+
+  /ember-get-config/2.0.0:
+    resolution: {integrity: sha512-FdT1iuldJZ8TRweh+wO9wcT86uVbW117aME6WCM+S0lPp282XH+3/aWVDD0hmcbBQC3aEV/Rs/vOv1mjBfeR0w==}
+    engines: {node: 12.* || 14.* || >= 16}
+    dependencies:
+      '@embroider/macros': 1.6.0
+      ember-cli-babel: 7.26.11
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /ember-load-initializers/2.1.2:
     resolution: {integrity: sha512-CYR+U/wRxLbrfYN3dh+0Tb6mFaxJKfdyz+wNql6cqTrA0BBi9k6J3AaKXj273TqvEpyyXegQFFkZEiuZdYtgJw==}
@@ -11622,7 +11634,7 @@ packages:
       is-yarn-global: 0.3.0
       latest-version: 5.1.0
       pupa: 2.1.1
-      semver: 7.3.5
+      semver: 7.3.7
       semver-diff: 3.1.1
       xdg-basedir: 4.0.0
     dev: true


### PR DESCRIPTION
Version 2.0 no longer returns `undefined` for the config in production builds